### PR TITLE
Fix Roman to Integer Conversion Algorithm

### DIFF
--- a/founding members 12/Roman to Integer/solution_fixed.py
+++ b/founding members 12/Roman to Integer/solution_fixed.py
@@ -1,0 +1,22 @@
+def romanToInt(self, s: str) -> int:
+    
+    numerals ={
+        "I": 1,
+        "V": 5,
+        "X": 10,
+        "L": 50,
+        "C": 100,
+        "D": 500,
+        "M": 1000
+    }
+    output = 0
+    i = 0
+    
+    while i < len(s):
+        if i + 1 < len(s) and numerals[s[i]] < numerals[s[i + 1]]:
+            output += (numerals[s[i + 1]] - numerals[s[i]])
+            i += 2
+        else:
+            output += numerals[s[i]]
+            i += 1
+    return output


### PR DESCRIPTION
## Bugs
The original `solution.py` had several critical bugs:
-  IndexError: Would crash when accessing `s[i+1]` at the last character
-  Incorrect subtraction logic: Used `j = i` making comparison always false
-  Wrong addition: Added `numerals[s[i+1]]` instead of `numerals[s[i]]` in normal cases

## Solution and changes made
Fixed the `romanToInt` function in `solution_fixed.py`:
- Line 16: Removed j = i (redundant variable)
- Line 17: Changed condition to compare with NEXT character, not same character
- Line 17: Added bounds check i + 1 < len(s)
- Line 18: Fixed subtraction to use s[i+1] - s[i]
- Line 21: Changed from numerals[s[i+1]] to numerals[s[i]]
- Restructured with proper if-else flow

## Changes summary
- Line 16: Changed condition to `if i + 1 < len(s) and numerals[s[i]] < numerals[s[i + 1]]:`
- Line 20: Changed to `output += numerals[s[i]]` in else block
- Removed `j` variable entirely
- Improved code structure and readability

## Testing
Verified with multiple test cases:
- Basic: III = 3, LVIII = 58, MCMXCIV = 1994
- Subtraction cases: IV = 4, IX = 9, XL = 40, XC = 90, CD = 400, CM = 900
- Edge cases: Single characters, maximum valid combinations
- All tests pass successfully

## Files Changed
- Created `solution_fixed.py` with corrected implementation
- (Original `solution.py` remains unchanged as per instructions)
