### PR TITLE
fix: median of two sorted array array

### DIFF
--- a/founding members 12/Median of Two Sorted Array/solution_fixed.py
+++ b/founding members 12/Median of Two Sorted Array/solution_fixed.py
@@ -1,0 +1,36 @@
+from typing import List
+
+
+def findMedianSortedArrays(nums1: List[int], nums2: List[int]) -> float:
+    if len(nums1) > len(nums2):
+        nums1, nums2 = nums2, nums1
+    
+    m, n = len(nums1), len(nums2)
+    left, right = 0, m
+
+    # Return nan immediately if arrays are empty
+    if (m + n) == 0:
+        return float("nan")
+    
+    while left <= right:
+        partition1 = (left + right) // 2
+        partition2 = (m + n + 1) // 2 - partition1
+        
+        maxLeft1 = float('-inf') if partition1 == 0 else nums1[partition1 - 1]
+        minRight1 = float('inf') if partition1 == m else nums1[partition1]
+        
+        maxLeft2 = float('-inf') if partition2 == 0 else nums2[partition2 - 1]
+        minRight2 = float('inf') if partition2 == n else nums2[partition2]
+        
+        if maxLeft1 <= minRight2 and maxLeft2 <= minRight1:
+            if (m + n) % 2 == 0:
+                return (max(maxLeft1, maxLeft2) + min(minRight1, minRight2)) / 2
+            else:
+                return max(maxLeft1, maxLeft2)
+        elif maxLeft1 > minRight2:
+            right = partition1 - 1
+        else:
+            left = partition1 + 1
+    
+    return 0.0
+


### PR DESCRIPTION
This fixes #8 

The following issues were found and fixed:

1. The `List` type was not imported
2. Empty arrays were not explicitly handled

Issue 1 was fixed by importing `List` from `typing`

I considered issue 2 an issue because the result would be `(-inf` + inf) / 2` which resolves to `nan`.
This is not intuitive and violates the python zen of being explicit.
It was fixed by returning `nan` if the total length of the arrays is 0