### PR TITLE
fix: fixed median of two sorted arrays List import

### DIFF
--- a/founding members 12/Median of Two Sorted Array/solution_fixed.py
+++ b/founding members 12/Median of Two Sorted Array/solution_fixed.py
@@ -1,0 +1,34 @@
+from typing import List # Import List for type hinting. This was missing in solutions.py
+
+def findMedianSortedArrays(nums1: List[int], nums2: List[int]) -> float:
+    if len(nums1) > len(nums2):
+        nums1, nums2 = nums2, nums1
+    
+    m, n = len(nums1), len(nums2)
+    left, right = 0, m
+    
+    while left <= right:
+        partition1 = (left + right) // 2
+        partition2 = (m + n + 1) // 2 - partition1 
+        
+        # Handling edge cases
+        maxLeft1 = float('-inf') if partition1 == 0 else nums1[partition1 - 1]
+        minRight1 = float('inf') if partition1 == m else nums1[partition1]
+        
+        maxLeft2 = float('-inf') if partition2 == 0 else nums2[partition2 - 1]
+        minRight2 = float('inf') if partition2 == n else nums2[partition2]
+        
+        # Found the correct partitions
+        if maxLeft1 <= minRight2 and maxLeft2 <= minRight1:
+            if (m + n) % 2 == 0:
+                return (max(maxLeft1, maxLeft2) + min(minRight1, minRight2)) / 2.0 # Ensured float division
+            else:
+                return float(max(maxLeft1, maxLeft2)) # Enforced the return value for type consistency
+            
+        # Adjust the binary search
+        elif maxLeft1 > minRight2:
+            right = partition1 - 1
+        else:
+            left = partition1 + 1
+    
+    return 0.0


### PR DESCRIPTION
**PR: Fix Median of Sorted Arrays logic
Changes:**

> Added from typing import List so the code actually runs.

> Forced the result to float to pass the return type requirements.

> Added a few comments to explain the partition math since it’s pretty dense.

The logic itself was solid, just needed some cleanup to handle the edge cases and imports properly.