### PR TITLE
fix: validate remaining open brackets in parentheses check

### DIFF
--- a/founding members 12/Valid P/solution_fixed.py
+++ b/founding members 12/Valid P/solution_fixed.py
@@ -1,0 +1,19 @@
+def isValid(self, s: str) -> bool:
+    open_brackets = {"(", "{", "["}
+    stack = []
+
+    for st in s:
+        if st in open_brackets:
+            stack.append(st)
+        else:
+            if not stack \
+                or (st == ")" and stack[-1] != "(") \
+                or (st == "}" and stack[-1] != "{") \
+                or (st == "]" and stack[-1] != "["):
+                return False
+            
+            stack.pop()
+
+    return len(stack) == 0
+
+


### PR DESCRIPTION
I reviewed the existing stack-based solution and identified a missing edge case.
While the logic correctly validates matching brackets during iteration, it did not verify that all opening brackets were closed after processing the input.
I fixed this by ensuring the stack is empty before returning True.
This preserves the original structure while correctly handling cases with unmatched opening brackets.