### PR TITLE
Fix bug in Longest Substring Without Repeating Characters solution

### DIFF
--- a/solution_fixed.py
+++ b/solution_fixed.py
@@ -1,0 +1,23 @@
+def lengthOfLongestSubstring(self, s: str) -> int:
+    n = len(s)
+    if n < 2:
+        return n
+
+    substr = set()
+    l, r = 0, 0   # start both at 0
+    max_l = 0
+
+    while r < n:
+        if s[r] in substr:
+            # shrink window until duplicate is removed
+            while s[l] != s[r]:
+                substr.remove(s[l])
+                l += 1
+            substr.remove(s[l])
+            l += 1
+        else:
+            substr.add(s[r])
+            r += 1
+            max_l = max(max_l, len(substr))
+
+    return max_l


### PR DESCRIPTION
The original code starts the right pointer at index 1, which ignores the first character and breaks the logic. When a duplicate is found, it only removes one character from the set. This can cause an infinite loop or leave duplicates behind.
Fix:
Start both pointers at index 0.
When a duplicate is encountered, move the left pointer forward and remove characters until the duplicate is gone.
The set always reflects the current substring window, and max_l is updated after each expansion.

Result:
The sliding window now works correctly and returns the proper length of the longest substring without repeating characters.


